### PR TITLE
Change the pre-commit .yml black version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
           - --remove-duplicate-keys
           - --remove-unused-variables
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/mirrors-prettier


### PR DESCRIPTION
This PR for change the Black version in pre-commit.yml file because we have Black version 22.3.0 in OCA 14.0 branch and in our ursais branch we have 20.8b1 it's not working when we do PR from ursais to OCA